### PR TITLE
change __file__ to "__file__"

### DIFF
--- a/examples/simple-piano.py
+++ b/examples/simple-piano.py
@@ -14,7 +14,7 @@ except ImportError:
 import pianohat
 
 
-BANK = os.path.join(os.path.dirname(__file__), "sounds")
+BANK = os.path.join(os.path.dirname("__file__"), "sounds")
 
 print("""
 This example gives you a simple, ready-to-play instrument which uses .wav files.


### PR DESCRIPTION
error when run with python 3.5.3 on Raspberry Pi

Traceback (most recent call last):
  file "/home/pi/Pimoroni/pianohat/examples/simple-piano.py", line 17, in <module>
    BANK = os.path.join(os.path.dirname(__file__), "sounds")
NameError: name '__file__' is not defined.

MNR note: this is fixed by quoting __file__, as noted in new branch

see https://stackoverflow.com/questions/16771894/python-nameerror-global-name-file-is-not-defined